### PR TITLE
fix: handle case when array already exists at path in IntermediateRep…

### DIFF
--- a/src/lib/imr.ts
+++ b/src/lib/imr.ts
@@ -289,7 +289,15 @@ export const addRuleOrGroup = (
 ): IntermediateRepresentation => {
   const fullPath = `nodes[${nodeId}].${pathString}`;
   const clonedImr = _.cloneDeep(imr);
-  _.set(clonedImr, fullPath, newObject);
+
+  const arrayAtPath = _.get(clonedImr, fullPath);
+
+  if (!Array.isArray(arrayAtPath)) {
+    _.set(clonedImr, fullPath, [newObject]);
+  } else {
+    arrayAtPath.push(newObject);
+  }
+
   return clonedImr;
 };
 


### PR DESCRIPTION
…resentation

The previous code would overwrite the existing value at the specified path with a new object. This change checks if an array already exists at the path, and if so, it appends the new object to the array instead of overwriting it.