### PR TITLE
feat: add showIndicator prop to Select component

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -13,6 +13,7 @@ type Props = {
   enableReset?: boolean;
   isSearchable?: boolean;
   defaultValue?: { value: string; label: string };
+  showIndicator?: boolean;
 };
 
 const Select = ({
@@ -24,6 +25,7 @@ const Select = ({
   enableReset = false,
   isSearchable,
   defaultValue,
+  showIndicator = true,
 }: Props) => {
   const [selectedValue, setSelectedValue] = useState<{
     value: string;
@@ -62,6 +64,7 @@ const Select = ({
         dropdownIndicator: (baseStyles) => ({
           ...baseStyles,
           padding: 0,
+          display: showIndicator ? "block" : "none",
         }),
       }}
       isSearchable={isSearchable}

--- a/src/components/dialogs/EntityEditor/Rule.tsx
+++ b/src/components/dialogs/EntityEditor/Rule.tsx
@@ -67,7 +67,8 @@ const Rule = ({ filter, nodeId, pathString }: Props) => {
           onSelect={(value) =>
             handleUpdate(nodeId, pathString, "operator", value)
           }
-          className="w-48"
+          className="w-10"
+          showIndicator={false}
         />
         <Input
           value={filter.value}


### PR DESCRIPTION
The Select component now accepts a new prop called showIndicator, which determines whether to display the dropdown indicator or not. By default, the dropdown indicator is shown. This allows for more flexibility in customizing the appearance of the Select component.